### PR TITLE
Local signer implementation

### DIFF
--- a/internal/export/exportfile.go
+++ b/internal/export/exportfile.go
@@ -22,10 +22,7 @@ import (
 	"crypto/sha256"
 	"fmt"
 	"sort"
-	"crypto/x509"
-	"encoding/pem"
-	"io/ioutil"
-	"crypto/ecdsa"
+
 	"github.com/google/exposure-notifications-server/internal/model"
 	"github.com/google/exposure-notifications-server/internal/pb/export"
 
@@ -59,7 +56,7 @@ func MarshalExportFile(eb *model.ExportBatch, exposures []*model.Exposure, batch
 	if err != nil {
 		return nil, fmt.Errorf("unable to marshal signature file: %w", err)
 	}
-	
+
 	// create compressed archive of binary and signature
 	buf := new(bytes.Buffer)
 	zw := zip.NewWriter(buf)
@@ -178,32 +175,9 @@ func marshalSignature(eb *model.ExportBatch, exportContents []byte, batchNum int
 func generateSignature(data []byte, signer crypto.Signer) ([]byte, error) {
 	digest := sha256.Sum256(data)
 
-	encPubb, _ := ioutil.ReadFile("gx-exposure-uy.pub")
-
-	encPrivb, _ := ioutil.ReadFile("gx-exposure-uy.priv")
-
-	encPub := string(encPubb)
-	encPriv := string(encPrivb)
-    priv2, _ := decode(encPriv, encPub)
-
-	r, s, err := ecdsa.Sign(rand.Reader, priv2, digest[:])
-	sig := r.Bytes()
-	sig = append(sig, s.Bytes()...)
+	sig, err := signer.Sign(rand.Reader, digest[:], nil)
 	if err != nil {
 		return nil, fmt.Errorf("unable to sign: %w", err)
 	}
 	return sig, nil
-}
-
-func decode(pemEncoded string, pemEncodedPub string) (*ecdsa.PrivateKey, *ecdsa.PublicKey) {
-    block, _ := pem.Decode([]byte(pemEncoded))
-    x509Encoded := block.Bytes
-    privateKey, _ := x509.ParseECPrivateKey(x509Encoded)
-
-    blockPub, _ := pem.Decode([]byte(pemEncodedPub))
-    x509EncodedPub := blockPub.Bytes
-    genericPublicKey, _ := x509.ParsePKIXPublicKey(x509EncodedPub)
-    publicKey := genericPublicKey.(*ecdsa.PublicKey)
-
-    return privateKey, publicKey
 }

--- a/internal/export/server_test.go
+++ b/internal/export/server_test.go
@@ -27,7 +27,7 @@ import (
 
 // TestNewServer tests NewServer().
 func TestNewServer(t *testing.T) {
-	emptyStorage := &storage.FileSystemCloudStorage{}
+	emptyStorage := &storage.FilesystemStorage{}
 	emptyKMS := &signing.GCPKMS{}
 	emptyDB := &database.DB{}
 	ctx := context.Background()

--- a/internal/setup/setup.go
+++ b/internal/setup/setup.go
@@ -76,9 +76,9 @@ func Setup(ctx context.Context, config DBConfigProvider) (*serverenv.ServerEnv, 
 
 	// TODO(mikehelmick): Make this extensible to other providers.
 	if _, ok := config.(KeyManagerProvider); ok {
-		km, err := signing.NewGCPKMS(ctx)
+		km, err := signing.NewLocalSigner()
 		if err != nil {
-	//		return nil, nil, fmt.Errorf("unable to connect to key manager: %w", err)
+			return nil, nil, fmt.Errorf("unable to connect to key manager: %w", err)
 		}
 		opts = append(opts, serverenv.WithKeyManager(km))
 	}

--- a/internal/signing/localsign.go
+++ b/internal/signing/localsign.go
@@ -1,0 +1,87 @@
+// Package signing defines the interface to and implementation of signing
+package signing
+
+import (
+	"context"
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+)
+
+// GCPKMS implements the signing.KeyManager interface and can be used to sign
+// export files.
+type LocalSigner struct{}
+
+func NewLocalSigner() (KeyManager, error) {
+	return &LocalSigner{}, nil
+}
+
+func (ls *LocalSigner) NewSigner(ctx context.Context, keyID string) (crypto.Signer, error) {
+	return &LocalSigner{}, nil
+}
+
+func (ls *LocalSigner) Public() crypto.PublicKey {
+	pubkey, _ := ReadPublicKeyFromFile()
+	return string(pubkey)
+}
+
+func ReadPublicKeyFromFile() (string, error) {
+	file, ok := os.LookupEnv("SIGN_PUBLIC_KEY_FILE")
+	if !ok {
+		file = "exposure-uy.pub"
+	}
+	encPubb, err := ioutil.ReadFile(file)
+	if err != nil {
+		return "", err
+	}
+	return string(encPubb), nil
+}
+
+func (ls *LocalSigner) Sign(rand io.Reader, digest []byte, opts crypto.SignerOpts) (signature []byte, err error) {
+	file, ok := os.LookupEnv("SIGN_PUBLIC_KEY_FILE")
+	if !ok {
+		file = "exposure-uy.priv"
+	}
+	encPrivb, err := ioutil.ReadFile(file)
+	if err != nil {
+		return nil, err
+	}
+	encPub, err := ReadPublicKeyFromFile()
+	if err != nil {
+		return nil, err
+	}
+	encPriv := string(encPrivb)
+	priv2, _, err := decode(encPriv, encPub)
+	if err != nil {
+		return nil, fmt.Errorf("unable to decode: %w", err)
+	}
+	r, s, err := ecdsa.Sign(rand, priv2, digest[:])
+	if err != nil {
+		return nil, fmt.Errorf("unable to sign: %w", err)
+	}
+	sig := r.Bytes()
+	sig = append(sig, s.Bytes()...)
+	return sig, nil
+}
+
+func decode(pemEncoded string, pemEncodedPub string) (*ecdsa.PrivateKey, *ecdsa.PublicKey, error) {
+	block, _ := pem.Decode([]byte(pemEncoded))
+	x509Encoded := block.Bytes
+	privateKey, err := x509.ParseECPrivateKey(x509Encoded)
+	if err != nil {
+		return nil, nil, err
+	}
+	blockPub, _ := pem.Decode([]byte(pemEncodedPub))
+	x509EncodedPub := blockPub.Bytes
+	genericPublicKey, err := x509.ParsePKIXPublicKey(x509EncodedPub)
+	if err != nil {
+		return nil, nil, err
+	}
+	publicKey := genericPublicKey.(*ecdsa.PublicKey)
+	return privateKey, publicKey, nil
+}

--- a/internal/signing/localsign.go
+++ b/internal/signing/localsign.go
@@ -43,7 +43,7 @@ func ReadPublicKeyFromFile() (string, error) {
 }
 
 func (ls *LocalSigner) Sign(rand io.Reader, digest []byte, opts crypto.SignerOpts) (signature []byte, err error) {
-	file, ok := os.LookupEnv("SIGN_PUBLIC_KEY_FILE")
+	file, ok := os.LookupEnv("SIGN_PRIVATE_KEY_FILE")
 	if !ok {
 		file = "exposure-uy.priv"
 	}


### PR DESCRIPTION
Instead of using the implementation directly in the export service a Local Signer implementation was done. 

The files to read the private and public key are read from files and can be taken from the SIGN_PUBLIC_KEY_FILE and SIGN_PRIVATE_KEY_FILE environment variables.